### PR TITLE
replace html2text with non-GPLed code

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 certifi>=2017.7.27.1
-html2text>=2016.9.19
 lxml>=3.8.0
+BeautifulSoup4

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     py_modules=['wptools'],
     packages=find_packages(exclude=['tests']),
     test_suite='tests.test_basic',
-    install_requires=['certifi', 'html2text', 'lxml'],
+    install_requires=['certifi', 'BeautifulSoup4', 'lxml'],
     include_package_data=True,
     entry_points={
         'console_scripts': ['wptool=wptools.wptool:main'],

--- a/wptools/page.py
+++ b/wptools/page.py
@@ -17,7 +17,7 @@ See also:
 - https://www.mediawiki.org/wiki/Manual:Page_table
 """
 
-import html2text
+from bs4 import BeautifulSoup
 
 from . import core
 from . import utils
@@ -321,7 +321,8 @@ class WPToolsPage(WPToolsRESTBase,
         extract = page.get('extract')
         if extract:
             self.data['extract'] = extract
-            extext = html2text.html2text(extract)
+            soup = BeautifulSoup(extract, 'html.parser')
+            extext = soup.get_text()
             if extext:
                 self.data['extext'] = extext.strip()
 


### PR DESCRIPTION
The license of wptools isn't actually MIT due to the usage of html2text. So replace it with BeautifulSoup. As an added bonus, it actually shows up as pure text and not markdown.